### PR TITLE
Allow edge and control daemon address to be configured via env variable

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,8 +1,11 @@
 // Configuration for the Gladius CLI
 
+// address of the control and edge daemon
+var address = process.env.ADDRESS || 'localhost';
+
 var network = {
   controlDaemonPort: 3000, // Port to access control daemon
-  controlDaemonAddress: "http://localhost", // What address to access the daemon
+  controlDaemonAddress: "http://" + address, // What address to access the daemon
   transferKeyOverHttp: true // Send file path or send actual key (used for docker)
 };
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ var rpcOptions = {
   // int port of rpc server, default 5080 for http or 5433 for https
   port: 5000,
   // string domain name or ip of rpc server, default '127.0.0.1'
-  host: 'localhost',
+  host: config.address,
   // string with default path, default '/'
   path: '/rpc',
   // boolean false to turn rpc checks off, default true


### PR DESCRIPTION
This PR allows the configuration of the address of the edge and control daemon to be configurable via the environment variable ADDRESS.

It will set the same address for the control daemon address and the RPC address of the edge daemon.